### PR TITLE
Chore/adapt ci to main branch

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,5 @@
 # vim: ft=yaml
+---
 skip_list:
- - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
- - '301'  # Commands should not change things if nothing needs doing
+ - 'role-name'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
+ - 'no-changed-when'  # Commands should not change things if nothing needs doing

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -4,10 +4,10 @@ name: 'symplegma-os_bootstrap'
 'on':
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   linter:
@@ -31,7 +31,7 @@ jobs:
           ansible-lint
 
   release:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     name: 'symplegma-os_bootstrap:release'
     runs-on: ubuntu-latest
     needs:
@@ -45,7 +45,7 @@ jobs:
         with:
           branches: |
             [
-              'master'
+              'main'
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -23,7 +23,8 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible yamllint ansible-lint
+        run: |
+          pip3 install ansible~=${{ secrets.ANSIBLE_VERSION }} yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # symplegma-os_bootstrap
 
-[![Build Status](https://travis-ci.org/clusterfrak-dynamics/symplegma-os_bootstrap.svg?branch=master)](https://travis-ci.org/clusterfrak-dynamics/symplegma-os_bootstrap)
+[![Build Status](https://github.com/particuleio/symplegma-os_bootstrap/workflows/symplegma-os_bootstrap/badge.svg)](https://github.com/particuleio/symplegma-os_bootstrap/workflows/symplegma-os_bootstrap/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 This ansible role bootstraps python 3 on CoreOS/Flatcar Linux and loads the necessary Kernel modules and parameters to deploy vanilla Kubernetes


### PR DESCRIPTION
- Set `main` as the default branch
- ansible-lint: use rule name instead of rule tag
- ci: specify ansible version using github secret ANSIBLE_VERSION