### PR TITLE
fix(swap): address specific swap configurations (missing fstab, no default swap on Flatcar Linux)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,3 +14,4 @@
 - include_tasks: requirements.yml
 
 - include_tasks: swap.yml
+  when: ansible_distribution != "Flatcar"

--- a/tasks/swap.yml
+++ b/tasks/swap.yml
@@ -3,8 +3,14 @@
   shell: |
     swapoff -a
 
+- name: Ensure fstab exists
+  stat:
+    path: /etc/fstab
+  register: fstab_file
+
 - name: Disable SWAP in fstab
   replace:
     path: /etc/fstab
     regexp: '^([^#].*?\sswap\s+sw\s+.*)$'
     replace: '# \1'
+  when: fstab_file.stat.exists


### PR DESCRIPTION
Prevent role execution failure on OSes that do not have `/etc/fstab`.
Completely skip swap management for `Flatcar` as the OS defaults do not provide swap.

> By default Flatcar Container Linux does not include a partition for swap [...]
[source](https://kinvolk.io/docs/flatcar-container-linux/latest/setup/storage/adding-swap/)

- Tested non regression using `molecule`
- Tested fix correctness by removing `/etc/fstab` on target

Closes #8
