### PR TITLE
ci: use latest ansible version and schedule every week

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible~=${{ secrets.ANSIBLE_VERSION }} yamllint ansible-lint
+          pip3 install ansible~=2.10 yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible~=2.10 yamllint ansible-lint
+          pip3 install ansible yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -2,6 +2,8 @@
 name: 'symplegma-os_bootstrap'
 
 'on':
+  schedule:
+    - cron: '0 7 * * 1'  # every monday at 7am
   push:
     branches:
       - main
@@ -32,7 +34,7 @@ jobs:
           ansible-lint
 
   release:
-    if: github.ref == 'refs/heads/main'
+    if: (github.ref == 'refs/heads/main' && github.event_event_name == 'push')
     name: 'symplegma-os_bootstrap:release'
     runs-on: ubuntu-latest
     needs:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,4 +8,4 @@
   with_items:
     - docker.service
     - docker.socket
-  ignore_errors: true
+  failed_when: false


### PR DESCRIPTION
Defining variables inside repository secrets causes them to not be available during action run caused by external PR
