### PR TITLE
fix(distro_packages): make sure ansible doesn't fail with exotic distributions

### DIFF
--- a/tasks/distro_packages.yml
+++ b/tasks/distro_packages.yml
@@ -2,12 +2,14 @@
 - name: Bootstrap | Gather variables for each operating system
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    files:
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+      - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+      - "{{ ansible_distribution | lower }}.yml"
+      - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+      - "{{ ansible_os_family | lower }}.yml"
+    skip: true
 
 - name: Bootstrap | Install specific distro packages
   package:


### PR DESCRIPTION
When no `vars/*.yml` file match the distribution name, the
`with_first_found` loop fails. With a `skip` parameter, as written in ansible
documentation, the task will be skipped.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/first_found_lookup.html#parameter-skip

Signed-off-by: Youenn Piolet <piolet.y@gmail.com>