### PR TITLE
feat(os_bootstrap): support archlinux

### DIFF
--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -1,0 +1,8 @@
+---
+distro_packages:
+  - conntrack-tools
+  - ethtool
+  - iproute2
+  - iptables
+  - socat
+  - util-linux


### PR DESCRIPTION
Add basic support of archlinux, mainly on distro_packages installed at bootstrap.

I didn't see the need of `ebtables`.

I have other missing sysctl parameters to set on archlinux but it may be linked to the CNI I use (cilium) so I don't address this issue in this PR.