### PR TITLE
fix(distro_packages): fix syntax of with_first_found loop

### DIFF
--- a/tasks/distro_packages.yml
+++ b/tasks/distro_packages.yml
@@ -2,14 +2,14 @@
 - name: Bootstrap | Gather variables for each operating system
   include_vars: "{{ item }}"
   with_first_found:
-    files:
-      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-      - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-      - "{{ ansible_distribution | lower }}.yml"
-      - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
-      - "{{ ansible_os_family | lower }}.yml"
-    skip: true
+    - files:
+        - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
+        - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+        - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+        - "{{ ansible_distribution | lower }}.yml"
+        - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+        - "{{ ansible_os_family | lower }}.yml"
+      skip: true
 
 - name: Bootstrap | Install specific distro packages
   package:


### PR DESCRIPTION
This is a fix for https://github.com/particuleio/symplegma-os_bootstrap/pull/11

[Clearly](https://github.com/ArchiFleKs?achievement=yolo&tab=achievements), no one tested this PR before approving :P

```
"an error occurred while trying to read the file '.../symplegma/roles/symplegma-os_bootstrap/files': [Errno 21] est un dossier: b'.../symplegma/roles/symplegma-os_bootstrap/files'. [Errno 21] est un dossier: b'.../symplegma/roles/symplegma-os_bootstrap/files'"
```